### PR TITLE
Use ArgumentOutOfRangeException

### DIFF
--- a/source/I2cConnectionSettings.cs
+++ b/source/I2cConnectionSettings.cs
@@ -77,7 +77,7 @@ namespace Windows.Devices.I2c
                 // better validate the address
                 if(value < 8 || value > 119)
                 {
-                    throw new ArgumentException();
+                    throw new ArgumentOutOfRangeException();
                 }
 
                 _slaveAddress = value;


### PR DESCRIPTION
Use ArgumentOutOfRangeException in property SlaveAddress after checking the range, instead of an ArgumentException.

## Motivation and Context
Using the right exception types may help consumers better identify what type of error they made.

## How Has This Been Tested?<!-- (if applicable) -->
Not tested by me.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: steffalk <stefan.falk@ct-systeme.com>