### PR TITLE
Add lazy initialization to I2cController

### DIFF
--- a/source/Windows.Devices.I2c/I2cController.cs
+++ b/source/Windows.Devices.I2c/I2cController.cs
@@ -13,10 +13,46 @@ namespace Windows.Devices.I2c
     /// </summary>
 	public sealed class I2cController
     {
-        // we can have only one instance of the I2cController
-        private static I2cController s_instance = new I2cController();
+        // this is used as the lock object 
+        // a lock is required because multiple threads can access the I2C controller
+        readonly static object _syncLock = new object();
 
-        internal static Hashtable s_deviceCollection = new Hashtable();
+        // we can have only one instance of the I2cController
+        // need to do a lazy initialization of this field to make sure it exists when called elsewhere.
+        private static I2cController s_instance;
+
+        // backing field for DeviceCollection
+        private static Hashtable s_deviceCollection;
+
+        /// <summary>
+        /// Device collection associated with this <see cref="I2cController"/>.
+        /// </summary>
+        /// <remarks>
+        /// This collection is for internal use only.
+        /// </remarks>
+        internal static Hashtable DeviceCollection
+        {
+            get
+            {
+                if (s_deviceCollection == null)
+                {
+                    lock (_syncLock)
+                    {
+                        if (s_deviceCollection == null)
+                        {
+                            s_deviceCollection = new Hashtable();
+                        }
+                    }
+                }
+
+                return s_deviceCollection;
+            }
+
+            set
+            {
+                s_deviceCollection = value;
+            }
+        }
 
         /// <summary>
         /// Gets the default I2C controller on the system.
@@ -24,6 +60,17 @@ namespace Windows.Devices.I2c
         /// <returns>The default I2C controller on the system, or null if the system has no I2C controller.</returns>
         public static I2cController GetDefault()
         {
+            if (s_instance == null)
+            {
+                lock (_syncLock)
+                {
+                    if (s_instance == null)
+                    {
+                        s_instance = new I2cController();
+                    }
+                }
+            }
+
             return s_instance;
         }
 

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -30,7 +30,7 @@ namespace Windows.Devices.I2c
             var deviceId = (i2cBus[3] - 48) * 1000 + settings.SlaveAddress;
 
             // check if this device ID already exists
-            if (!I2cController.s_deviceCollection.Contains(deviceId))
+            if (!I2cController.DeviceCollection.Contains(deviceId))
             {
                 _connectionSettings = new I2cConnectionSettings(settings.SlaveAddress)
                 {
@@ -44,7 +44,7 @@ namespace Windows.Devices.I2c
                 NativeInit();
 
                 // add to device collection
-                I2cController.s_deviceCollection.Add(deviceId, this);
+                I2cController.DeviceCollection.Add(deviceId, this);
             }
             /*
             else
@@ -215,7 +215,7 @@ namespace Windows.Devices.I2c
                 if (disposing)
                 {
                     // remove from device collection
-                    I2cController.s_deviceCollection.Remove(_deviceId);
+                    I2cController.DeviceCollection.Remove(_deviceId);
                 }
 
                 DisposeNative();


### PR DESCRIPTION
## Description
- Add lazy initialization to I2cController.
- Also changed DeviceCollection making it accessible as property.

## Motivation and Context
- Make sure that the variables do exist when being used. Using the previous code was causing issues because on occasions the types could still be unresolved.
- Addresses nanoFramework/Home#421.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>