### PR TITLE
Fix lazy init and prevent un-necessary calls to NativeInit

### DIFF
--- a/source/Windows.Devices.I2c/I2cController.cs
+++ b/source/Windows.Devices.I2c/I2cController.cs
@@ -24,6 +24,9 @@ namespace Windows.Devices.I2c
         // backing field for DeviceCollection
         private static Hashtable s_deviceCollection;
 
+        // field to keep track on how many different I2C buses are being used
+        private static ArrayList s_busIdCollection;
+
         /// <summary>
         /// Device collection associated with this <see cref="I2cController"/>.
         /// </summary>
@@ -38,10 +41,7 @@ namespace Windows.Devices.I2c
                 {
                     lock (_syncLock)
                     {
-                        if (s_deviceCollection == null)
-                        {
-                            s_deviceCollection = new Hashtable();
-                        }
+                        s_deviceCollection = new Hashtable();
                     }
                 }
 
@@ -51,6 +51,32 @@ namespace Windows.Devices.I2c
             set
             {
                 s_deviceCollection = value;
+            }
+        }
+        /// <summary>
+        /// I2C bus collection associated with this <see cref="I2cController"/>.
+        /// </summary>
+        /// <remarks>
+        /// This collection is for internal use only.
+        /// </remarks>
+        internal static ArrayList BusIdCollection
+        {
+            get
+            {
+                if (s_busIdCollection == null)
+                {
+                    lock (_syncLock)
+                    {
+                        s_busIdCollection = new ArrayList();
+                    }
+                }
+
+                return s_busIdCollection;
+            }
+
+            set
+            {
+                s_busIdCollection = value;
             }
         }
 
@@ -64,10 +90,7 @@ namespace Windows.Devices.I2c
             {
                 lock (_syncLock)
                 {
-                    if (s_instance == null)
-                    {
-                        s_instance = new I2cController();
-                    }
+                    s_instance = new I2cController();
                 }
             }
 

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -41,8 +41,13 @@ namespace Windows.Devices.I2c
                 // save device ID
                 _deviceId = deviceId;
 
-                NativeInit();
-
+                //Instantiate I2C bus once for each bus used
+                if( !I2cController.BusIdCollection.Contains(i2cBus))
+                {
+                    I2cController.BusIdCollection.Add(i2cBus);
+                    NativeInit();
+                }
+                
                 // add to device collection
                 I2cController.DeviceCollection.Add(deviceId, this);
             }


### PR DESCRIPTION
Prevent un-necessary calls to "NativeInit" (I2C)

## Description
Everytime "I2cDevice.FromId" method is called, the "NativeInit" method gets called. This method should be called only once per I2C bus. This fix ensures that NativeInit is called only when a new I2C bus is used in managed code

## Motivation and Context
1. Improve code
2. Another attempt to fix I2C hang issue as reported in nanoFramework/Home#416 and nanoFramework/Home#424

## How Has This Been Tested?<!-- (if applicable) -->
Tested with HTU21D I2C sensor. So far have been able to debug multiple times with no I2C hang. 
## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: @sharmavishnu 
