### PR TITLE
Fix issue with I2C NativeInit and Dispose

### DIFF
--- a/source/Windows.Devices.I2c/I2cController.cs
+++ b/source/Windows.Devices.I2c/I2cController.cs
@@ -41,7 +41,10 @@ namespace Windows.Devices.I2c
                 {
                     lock (_syncLock)
                     {
-                        s_deviceCollection = new Hashtable();
+                        if (s_deviceCollection == null)
+                        {
+                            s_deviceCollection = new Hashtable();
+                        }
                     }
                 }
 
@@ -67,7 +70,10 @@ namespace Windows.Devices.I2c
                 {
                     lock (_syncLock)
                     {
-                        s_busIdCollection = new ArrayList();
+                        if (s_busIdCollection == null)
+                        {
+                            s_busIdCollection = new ArrayList();
+                        }
                     }
                 }
 
@@ -90,7 +96,10 @@ namespace Windows.Devices.I2c
             {
                 lock (_syncLock)
                 {
-                    s_instance = new I2cController();
+                    if (s_instance == null)
+                    {
+                        s_instance = new I2cController();
+                    }
                 }
             }
 

--- a/source/Windows.Devices.I2c/I2cController.cs
+++ b/source/Windows.Devices.I2c/I2cController.cs
@@ -24,6 +24,9 @@ namespace Windows.Devices.I2c
         // backing field for DeviceCollection
         private static Hashtable s_deviceCollection;
 
+        // field to keep track on how many different I2C buses are being used
+        private static ArrayList s_busIdCollection;
+
         /// <summary>
         /// Device collection associated with this <see cref="I2cController"/>.
         /// </summary>
@@ -38,10 +41,7 @@ namespace Windows.Devices.I2c
                 {
                     lock (_syncLock)
                     {
-                        if (s_deviceCollection == null)
-                        {
-                            s_deviceCollection = new Hashtable();
-                        }
+                        s_deviceCollection = new Hashtable();
                     }
                 }
 
@@ -51,6 +51,32 @@ namespace Windows.Devices.I2c
             set
             {
                 s_deviceCollection = value;
+            }
+        }
+        /// <summary>
+        /// I2C bus collection associated with this <see cref="I2cController"/>.
+        /// </summary>
+        /// <remarks>
+        /// This collection is for internal use only.
+        /// </remarks>
+        internal static ArrayList BusIdCollection
+        {
+            get
+            {
+                if (s_busIdCollection == null)
+                {
+                    lock (_syncLock)
+                    {
+                        s_busIdCollection = new ArrayList();
+                    }
+                }
+
+                return s_busIdCollection;
+            }
+
+            set
+            {
+                s_busIdCollection = value;
             }
         }
 
@@ -64,10 +90,7 @@ namespace Windows.Devices.I2c
             {
                 lock (_syncLock)
                 {
-                    if (s_instance == null)
-                    {
-                        s_instance = new I2cController();
-                    }
+                    s_instance = new I2cController();
                 }
             }
 

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -42,9 +42,9 @@ namespace Windows.Devices.I2c
                 _deviceId = deviceId;
 
                 //Instantiate I2C bus once for each bus used
-                if( !I2cController.BusIdCollection.Contains(i2cBus[3] - 48))
+                if( !I2cController.BusIdCollection.Contains((uint)(i2cBus[3] - 48)))
                 {
-                    I2cController.BusIdCollection.Add(i2cBus[3] - 48);
+                    I2cController.BusIdCollection.Add((uint)(i2cBus[3] - 48));
                     NativeInit();
                 }
                 

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -221,6 +221,25 @@ namespace Windows.Devices.I2c
                 {
                     // remove from device collection
                     I2cController.DeviceCollection.Remove(_deviceId);
+                    /*
+                     * Clear the bus Id from the collection, only if, no other device is using the bus.
+                     * A device Id is 4 digit and starts with digit 1,2,3 etc...which is the bus Id (see FromId method)
+                     */
+                    uint busId = (uint)(_deviceId / 1000);
+                    bool hasDeviceUsingBus = false;
+                    foreach(uint existingDeviceId in I2cController.DeviceCollection.Keys)
+                    {
+                        if((uint)(existingDeviceId/1000) == busId)
+                        {
+                            hasDeviceUsingBus = true;
+                            break;
+                        }
+                    }
+                    if (!hasDeviceUsingBus)
+                    {
+                        //no more registered devices using the bus..dispose it
+                        I2cController.BusIdCollection.Remove(busId);
+                    }
                 }
 
                 DisposeNative();

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -42,9 +42,9 @@ namespace Windows.Devices.I2c
                 _deviceId = deviceId;
 
                 //Instantiate I2C bus once for each bus used
-                if( !I2cController.BusIdCollection.Contains(i2cBus))
+                if( !I2cController.BusIdCollection.Contains(i2cBus[3] - 48))
                 {
-                    I2cController.BusIdCollection.Add(i2cBus);
+                    I2cController.BusIdCollection.Add(i2cBus[3] - 48);
                     NativeInit();
                 }
                 

--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -41,8 +41,13 @@ namespace Windows.Devices.I2c
                 // save device ID
                 _deviceId = deviceId;
 
-                NativeInit();
-
+                //Instantiate I2C bus once for each bus used
+                if( !I2cController.BusIdCollection.Contains(i2cBus))
+                {
+                    I2cController.BusIdCollection.Add(i2cBus);
+                    NativeInit();
+                }
+                
                 // add to device collection
                 I2cController.DeviceCollection.Add(deviceId, this);
             }


### PR DESCRIPTION
Fix for Dispose
## Description
Found out that the bus Id collection, code was adding the full selector name whereas during dispose, it was only removing the bus Id.

## Motivation and Context
Ensure Bus Id collection is always in sync with the associated devices, else NativeInit would be called wrongly.
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Resolves nanoFramework/Home#421.

## How Has This Been Tested?<!-- (if applicable) -->
Tested with two different I2C devices on the bus

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: @sharmavishnu 
