### PR TITLE
Rework I2cController and I2cDevice

### DIFF
--- a/source/Windows.Devices.I2c/I2cConnectionSettings.cs
+++ b/source/Windows.Devices.I2c/I2cConnectionSettings.cs
@@ -12,8 +12,13 @@ namespace Windows.Devices.I2c
     /// </summary>
 	public sealed class I2cConnectionSettings
     {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private Int32 _slaveAddress;
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private I2cBusSpeed _busSpeed;
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private I2cSharingMode _sharingMode;
 
         /// <summary>

--- a/source/Windows.Devices.I2c/I2cControllerManager.cs
+++ b/source/Windows.Devices.I2c/I2cControllerManager.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections;
+
+namespace Windows.Devices.I2c
+{
+    internal sealed class I2cControllerManager
+    {
+        private static readonly object _syncLock = new object();
+
+        // backing field for ControllersCollection
+        // to store the controllers that are open
+        private static Hashtable s_controllersCollection;
+
+        /// <summary>
+        /// <see cref="I2cController"/> collection.
+        /// </summary>
+        /// <remarks>
+        /// This collection is for internal use only.
+        /// </remarks>
+        internal static Hashtable ControllersCollection
+        {
+            get
+            {
+                if (s_controllersCollection == null)
+                {
+                    lock (_syncLock)
+                    {
+                        if (s_controllersCollection == null)
+                        {
+                            s_controllersCollection = new Hashtable();
+                        }
+                    }
+                }
+
+                return s_controllersCollection;
+            }
+
+            set
+            {
+                s_controllersCollection = value;
+            }
+        }
+    }
+}

--- a/source/Windows.Devices.I2c/I2cTransferResult.cs
+++ b/source/Windows.Devices.I2c/I2cTransferResult.cs
@@ -11,7 +11,10 @@ namespace Windows.Devices.I2c
     /// </summary>
 	public struct I2cTransferResult
     {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private uint _bytesTransferred;
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private I2cTransferStatus _status;
 
         /// <summary>

--- a/source/Windows.Devices.I2c/Windows.Devices.I2c.nfproj
+++ b/source/Windows.Devices.I2c/Windows.Devices.I2c.nfproj
@@ -53,6 +53,7 @@
     <Compile Include="I2cBusSpeed.cs" />
     <Compile Include="I2cConnectionSettings.cs" />
     <Compile Include="I2cController.cs" />
+    <Compile Include="I2cControllerManager.cs" />
     <Compile Include="I2cDevice.cs" />
     <Compile Include="I2cSharingMode.cs" />
     <Compile Include="I2cTransferResult.cs" />


### PR DESCRIPTION
## Description
- Rework I2cController class to allow multiple instances.
- Add new internal class to handle multiple I2cController.
- Rework I2cDevice class accordingly.
- Decorate fields with DebuggerBrowsableState to hide them on debug session.

## Motivation and Context
- Current implementation only supported a single controller.
- Improve the debugging experience.
- Fixes nanoFramework/Home#421

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>