### PR TITLE
Fix bug with controller search and indexing #35 

### DIFF
--- a/source/Windows.Devices.I2c/I2cController.cs
+++ b/source/Windows.Devices.I2c/I2cController.cs
@@ -58,18 +58,20 @@ namespace Windows.Devices.I2c
 
         internal I2cController(string controller)
         {
+            // the I2C id is an ASCII string with the format 'I2Cn'
+            // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+            _controllerId = controller[3] - '0';
+
             // check if this controller is already opened
-            if (!I2cControllerManager.ControllersCollection.Contains(controller))
+            if (!I2cControllerManager.ControllersCollection.Contains(_controllerId))
             {
-                // the I2C id is an ASCII string with the format 'I2Cn'
-                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
-                _controllerId = controller[3] - '0';
 
                 // call native init to allow HAL/PAL inits related with I2C hardware
                 // this is also used to check if the requested ADC actually exists
                 NativeInit();
 
-                // add controller to collection, with the ID as key (just the index number)
+                // add controller to collection, with the ID as key 
+                // *** just the index number ***
                 I2cControllerManager.ControllersCollection.Add(_controllerId, this);
             }
             else
@@ -90,10 +92,14 @@ namespace Windows.Devices.I2c
 
             if (controllers.Length > 0)
             {
-                if (I2cControllerManager.ControllersCollection.Contains(controllers[0]))
+                // the I2C id is an ASCII string with the format 'I2Cn'
+                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+                var controllerId = controllers[0][3] - '0';
+
+                if (I2cControllerManager.ControllersCollection.Contains(controllerId))
                 {
                     // controller is already open
-                    return (I2cController)I2cControllerManager.ControllersCollection[controllers[0]];
+                    return (I2cController)I2cControllerManager.ControllersCollection[controllerId];
                 }
                 else
                 {


### PR DESCRIPTION
## Description
- Controller collection is now searched with the correct index.

## Motivation and Context
- Collection was being searched sometimes with the full AQS and other with the index. Now it's consistently stored and searched with index only.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
