### PR TITLE
Work on I2cDevice dispose

### DIFF
--- a/source/Windows.Devices.I2c/I2cDevice.cs
+++ b/source/Windows.Devices.I2c/I2cDevice.cs
@@ -251,6 +251,8 @@ namespace Windows.Devices.I2c
         {
             if (!_disposed)
             {
+                bool disposeController = false;
+
                 if (disposing)
                 {
                     // get the controller Id
@@ -266,10 +268,13 @@ namespace Windows.Devices.I2c
                         I2cControllerManager.ControllersCollection.Remove(controller);
 
                         controller = null;
+
+                        // flag this to native dispose
+                        disposeController = true;
                     }
                 }
 
-                DisposeNative();
+                NativeDispose(disposeController);
 
                 _disposed = true;
             }
@@ -302,7 +307,7 @@ namespace Windows.Devices.I2c
         private extern void NativeInit();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern void DisposeNative();
+        private extern void NativeDispose(bool disposeController);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern I2cTransferResult NativeTransmit(byte[] writeBuffer, byte[] readBuffer);


### PR DESCRIPTION
## Description
- Add argument in native dispose call to request dispose of "native controller".
- Rename method to NativeDispose to follow general naming.

## Motivation and Context
- Passing this argument to native call helps the lower layer to make the required calls to free resources, if that the bus is no longer in use.
- Rename method to NativeDispose to follow general naming.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>